### PR TITLE
fix: export type TaskFunction & TaskInnerApi

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"scripts": {
 		"lint": "eslint .",
 		"test": "jest",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsc --noEmit && :",
 		"build": "rm -rf dist && tsup src/index.ts --dts --minify --no-splitting --external 'yoga-layout-prebuilt'"
 	},
 	"husky": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,19 +37,20 @@ const createTaskInnerApi = (taskState: TaskObject) => {
 };
 
 namespace task {
-	export type TaskFunction = (taskHelpers: ReturnType<typeof createTaskInnerApi>) => Promise<unknown>;
+	export type TaskInnerApi = ReturnType<typeof createTaskInnerApi>;
+	export type TaskFunction = (taskHelpers: TaskInnerApi) => Promise<unknown>;
 }
 
-type TaskAPI<T extends task.TaskFunction> = {
+type TaskApi<T extends task.TaskFunction> = {
 	run: () => Promise<Awaited<ReturnType<T>>>;
 	clear: () => void;
 };
 type TaskResults<
 	T extends task.TaskFunction,
-	Tasks extends TaskAPI<T>[]
+	Tasks extends TaskApi<T>[]
 > = {
 	[key in keyof Tasks]: (
-		Tasks[key] extends TaskAPI<T>
+		Tasks[key] extends TaskApi<T>
 			? Awaited<ReturnType<Tasks[key]['run']>>
 			: Tasks[key]
 	);
@@ -61,7 +62,7 @@ function registerTask<T extends task.TaskFunction>(
 	taskList: TaskList,
 	taskTitle: string,
 	taskFunction: T,
-): TaskAPI<T> {
+): TaskApi<T> {
 	if (!app) {
 		app = createApp(taskList);
 		taskList.isRoot = true;
@@ -131,7 +132,7 @@ function createTaskFunction(
 
 	task.group = async <
 		T extends task.TaskFunction,
-		Tasks extends TaskAPI<T>[]
+		Tasks extends TaskApi<T>[]
 	>(
 		createTasks: (taskCreator: typeof createTask) => readonly [...Tasks],
 		options?: Options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,14 +36,16 @@ const createTaskInnerApi = (taskState: TaskObject) => {
 	return api;
 };
 
-type TaskFunction = (taskHelpers: ReturnType<typeof createTaskInnerApi>) => Promise<unknown>;
+namespace task {
+	export type TaskFunction = (taskHelpers: ReturnType<typeof createTaskInnerApi>) => Promise<unknown>;
+}
 
-type TaskAPI<T extends TaskFunction> = {
+type TaskAPI<T extends task.TaskFunction> = {
 	run: () => Promise<Awaited<ReturnType<T>>>;
 	clear: () => void;
 };
 type TaskResults<
-	T extends TaskFunction,
+	T extends task.TaskFunction,
 	Tasks extends TaskAPI<T>[]
 > = {
 	[key in keyof Tasks]: (
@@ -55,7 +57,7 @@ type TaskResults<
 
 let app: ReturnType<typeof createApp>;
 
-function registerTask<T extends TaskFunction>(
+function registerTask<T extends task.TaskFunction>(
 	taskList: TaskList,
 	taskTitle: string,
 	taskFunction: T,
@@ -105,7 +107,7 @@ function registerTask<T extends TaskFunction>(
 function createTaskFunction(
 	taskList: TaskList,
 ) {
-	async function task<T extends TaskFunction>(
+	async function task<T extends task.TaskFunction>(
 		title: string,
 		taskFunction: T,
 	) {
@@ -118,7 +120,7 @@ function createTaskFunction(
 		);
 	}
 
-	const createTask = <T extends TaskFunction>(
+	const createTask = <T extends task.TaskFunction>(
 		title: string,
 		taskFunction: T,
 	) => registerTask(
@@ -128,7 +130,7 @@ function createTaskFunction(
 		);
 
 	task.group = async <
-		T extends TaskFunction,
+		T extends task.TaskFunction,
 		Tasks extends TaskAPI<T>[]
 	>(
 		createTasks: (taskCreator: typeof createTask) => readonly [...Tasks],

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ const createTaskInnerApi = (taskState: TaskObject) => {
 	return api;
 };
 
+// Until full ESM
+// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace task {
 	export type TaskInnerApi = ReturnType<typeof createTaskInnerApi>;
 	export type TaskFunction = (taskHelpers: TaskInnerApi) => Promise<unknown>;


### PR DESCRIPTION
Closes https://github.com/privatenumber/tasuku/issues/1

This enables using types like:

```ts
import task from 'tasuku'

const doSomething: task.TaskFunction = (api) => {
    // ...
}

// alternatively:

function doSomething(api: task.TaskInnerApi) {
    // ...
}
```


Note, the types are exported as properties of the default export `task`, because this package is current CJS. I considered adding a ESM/CJS version with a discrepancy in exports, but [TS currently doesn't support export maps](https://github.com/microsoft/TypeScript/issues/33079).