### PR TITLE
fix: fix top-level-task-error-problem.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,10 @@ function createTaskFunction(
 		taskFunction,
 	) => {
 		const registeredTask = registerTask(taskList, title, taskFunction);
-		const result = await registeredTask[runSymbol]();
-
+		let result;
+		try {
+			result = await registeredTask[runSymbol]();
+		} catch (err) { }
 		return {
 			result,
 			get state() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type RegisteredTask<T = unknown> = {
 };
 
 export type TaskAPI<Result = unknown> = {
-	result: Result;
+	result: Result | undefined;
 	state: State;
 	clear: () => void;
 };


### PR DESCRIPTION
I believe this change could help with the issue #23 and it actually helped me.

old:
```js
  let obj;
  try {
    obj = await task('Task 1', async () => {
      await sleep(1000);
      throw 'error';
    });
  } catch (err) {
    console.log('is ok');
  }

  console.log(obj);
  // => undefined
  obj.clear();
  // obj is undefined
```

new:
```js
  let obj;
  try {
    obj = await task('Task 1', async () => {
      await sleep(1000);
      throw 'error';
    });
  } catch (err) {
    console.log('is ok');
  }

  console.log(obj);
  // => {result: undefined, clear: Function, ...}
  obj.clear();
  // work !
```